### PR TITLE
\footnote(\ifydir) for TeX Live 2015

### DIFF
--- a/word-lua.dtx
+++ b/word-lua.dtx
@@ -3158,9 +3158,8 @@
 % もし脚注番号が空なら記号も出力しないようにしてあります。
 %
 %    \begin{macrocode}
-\renewcommand\@makefnmark{\hbox{}\hbox{%
-  \ifydir \@textsuperscript{\normalfont\@thefnmark}%
-  \else\hbox{\yoko\@textsuperscript{\normalfont\@thefnmark}}\fi}\hbox{}}
+\def\@makefnmark{\hbox{\unless\ifnum\ltjgetparameter{direction}=3 $\m@th^{\@thefnmark}$
+      \else\hbox{\yoko$\m@th^{\@thefnmark}$}\fi}}%
 %    \end{macrocode}
 % \end{macro}
 %

--- a/word-lua.dtx
+++ b/word-lua.dtx
@@ -3158,7 +3158,7 @@
 % もし脚注番号が空なら記号も出力しないようにしてあります。
 %
 %    \begin{macrocode}
-\def\@makefnmark{\hbox{\unless\ifnum\ltjgetparameter{direction}=3 $\m@th^{\@thefnmark}$
+\renewcommand\@makefnmark{\hbox{\unless\ifnum\ltjgetparameter{direction}=3 $\m@th^{\@thefnmark}$
       \else\hbox{\yoko$\m@th^{\@thefnmark}$}\fi}}%
 %    \end{macrocode}
 % \end{macro}


### PR DESCRIPTION
`\footnote` に使われる `\ifydir` 命令がTeX Live 2015の `lualatex` では実行できなくなったようなので､こちらも変えました｡機室のTeX Live 2015ではこの変更でもコンパイルできることを確認しています｡おそらく2014でも問題ないだろう｡
