### PR TITLE
ライセンスの明示

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,24 @@
+Copyright (c) 2016, WORD
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of the WORD nor the
+      names of its contributors may be used to endorse or promote products
+      derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL <COPYRIGHT HOLDER> BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/README.md
+++ b/README.md
@@ -20,3 +20,7 @@ WORD Class
 - word-luaのみの機能
 	+ `\authormark{hoge}`で、著者名前の「文 編集部」を編集できる。
 	+ `swapheader`オプションで、ヘッダの位置を入れ替えられる。記事が偶数ページから始まる時に便利。
+
+# ライセンス
+
+License: modified BSD (see LICENSE)

--- a/word-lua.dtx
+++ b/word-lua.dtx
@@ -31,7 +31,7 @@
 %<*driver>
 \ProvidesFile{word-lua.dtx}
 %</driver>
-  [2015/05/11 v0.1 ]
+  [2016/07/12 v1.0]
 %<*driver>
 \documentclass{ltjsarticle}
 \usepackage{doc}
@@ -77,6 +77,8 @@
 % \MakeShortVerb{\|}
 % これは|ltjsclasses.dtx|をWORD用に改変したものです｡
 % 次のドキュメントクラス（スタイルファイル）を生成します。
+% 元となった|ltjsclasses.dtx|と同様に、このクラスファイルのライセンスは
+% 修正BSDライセンスとします。
 % \DeleteShortVerb{\|}
 % \begin{quote}
 %   \begin{tabular}{l|l}

--- a/word.dtx
+++ b/word.dtx
@@ -28,6 +28,7 @@
 % \StopEventually{}
 %
 % \iffalse
+% \changes{v1.00}{2016/7/2}{ライセンスを明示}
 % \changes{v1.00}{2013/12/27}{dtxファイルへ移行}
 % \fi
 %
@@ -38,7 +39,7 @@
 %</driver>
 %<book>\ProvidesClass{word}
 %<geometry>\ProvidesFile{word.clo}
-  [2013/12/27 v1.0
+  [2016/7/2 v1.01
 	WORD Standard pLaTeX class]
 %<*driver>
 \documentclass{jltxdoc}


### PR DESCRIPTION
- ライセンスファイルを明示するファイル`LICENSE`の追加
- 各`dtx`ファイルにライセンス情報を追記
- `README.md`にもライセンス情報を追記
