### PR TITLE
バージョン指定を修正

### DIFF
--- a/word-lua.dtx
+++ b/word-lua.dtx
@@ -31,7 +31,7 @@
 %<*driver>
 \ProvidesFile{word-lua.dtx}
 %</driver>
-  [2016/07/12 v1.0]
+  [2016/7/2 v1.0]
 %<*driver>
 \documentclass{ltjsarticle}
 \usepackage{doc}

--- a/word.dtx
+++ b/word.dtx
@@ -28,8 +28,8 @@
 % \StopEventually{}
 %
 % \iffalse
-% \changes{v1.00}{2016/7/2}{ライセンスを明示}
-% \changes{v1.00}{2013/12/27}{dtxファイルへ移行}
+% \changes{1.00}{2013/12/27}{dtxファイルへ移行}
+% \changes{1.01}{2016/7/2}{ライセンスを明示}
 % \fi
 %
 % \iffalse
@@ -39,15 +39,15 @@
 %</driver>
 %<book>\ProvidesClass{word}
 %<geometry>\ProvidesFile{word.clo}
-  [2016/7/2 v1.01
+  [2016/7/2 1.01
 	WORD Standard pLaTeX class]
 %<*driver>
 \documentclass{jltxdoc}
 \GetFileInfo{word.dtx}
 \usepackage[dvipdfmx, colorlinks]{hyperref}
 \usepackage{pxjahyper}
-\def\fileversion{v1.0}
-\def\filedate{2014/4/29}
+\def\fileversion{1.01}
+\def\filedate{2016/7/2}
 \title{WORD Standard Class\space\fileversion}
 \author{Hikaru \sc{Yoshimura}\and Kazuhiko \sc{Sakaguchi}}
 \date{\filedate}


### PR DESCRIPTION
なぜか、`v`が入っているとこのクラスファイルを用いたコンパイルに失敗するという問題が発生したため、とりあえずバージョン情報から`v`を削除した。
さらに、`word-lua.dtx`の日付け情報が間違っていたので、それも修正した。
