### PR TITLE
バージョン情報を修正

### DIFF
--- a/word-lua.dtx
+++ b/word-lua.dtx
@@ -31,7 +31,7 @@
 %<*driver>
 \ProvidesFile{word-lua.dtx}
 %</driver>
-  [2016/7/2 v1.0]
+  [2016/7/2 1.0]
 %<*driver>
 \documentclass{ltjsarticle}
 \usepackage{doc}


### PR DESCRIPTION
LuaTeXでもバージョンに`v`を含むとコンパイルができなくなってしまったので、ひとまず`v`を削除してコンパイルが通るようにした。
