### PR TITLE
Switchable LuaTeX between v0.8x and the laters

### DIFF
--- a/word-lua.dtx
+++ b/word-lua.dtx
@@ -328,9 +328,9 @@
   local pagewidth, pageheight
   if version < 90 then
     pagewidth = \asluastring{\pdfpagewidth}
-	pageheight = \asluastring{\pdfpageheight}
+    pageheight = \asluastring{\pdfpageheight}
   else
-  pagewidth = \asluastring{\pagewidth}
+    pagewidth = \asluastring{\pagewidth}
     pageheight = \asluastring{\pageheight}
   end
 

--- a/word-lua.dtx
+++ b/word-lua.dtx
@@ -322,9 +322,27 @@
 %
 %
 % \paragraph{PDFの用紙サイズの設定}
-%
-% \begin{macro}{\pdfpagewidth}
-% \begin{macro}{\pdfpageheight}
+\directlua{
+  local t = lua.get_functions_table()
+  local version = status.luatex_version
+  local pagewidth, pageheight
+  if version < 90 then
+    pagewidth = [[\pdfpagewidth]]
+    pageheight = [[\pdfpageheight]]
+  else
+    pagewidth = [[\pagewidth]]
+    pageheight = [[\pageheight]]
+  end
+
+  t[101] = function()
+    tex.print(pagewidth)
+  end
+  t[102] = function()
+    tex.print(pageheight)
+  end
+}
+% \begin{macro}{\luafunction101}
+% \begin{macro}{\luafunction102}
 % 出力のPDFの用紙サイズをここで設定しておきます。
 % |tombow| が真のときは2インチ足しておきます。
 %    \begin{macrocode}
@@ -334,8 +352,8 @@
   \advance \@tempdima 2in
   \advance \@tempdimb 2in
 \fi
-\setlength{\pdfpagewidth}{\@tempdima}
-\setlength{\pdfpageheight}{\@tempdimb}
+\setlength{\luafunction101}{\@tempdima}
+\setlength{\luafunction102}{\@tempdimb}
 %    \end{macrocode}
 % \end{macro}
 % \end{macro}

--- a/word-lua.dtx
+++ b/word-lua.dtx
@@ -327,11 +327,11 @@
   local version = status.luatex_version
   local pagewidth, pageheight
   if version < 90 then
-    pagewidth = [[\pdfpagewidth]]
-    pageheight = [[\pdfpageheight]]
+    pagewidth = \asluastring{\pdfpagewidth}
+	pageheight = \asluastring{\pdfpageheight}
   else
-    pagewidth = [[\pagewidth]]
-    pageheight = [[\pageheight]]
+  pagewidth = \asluastring{\pagewidth}
+    pageheight = \asluastring{\pageheight}
   end
 
   t[101] = function()

--- a/word-lua.dtx
+++ b/word-lua.dtx
@@ -31,7 +31,7 @@
 %<*driver>
 \ProvidesFile{word-lua.dtx}
 %</driver>
-  [2016/7/2 1.0]
+  [2016/7/8 1.1]
 %<*driver>
 \documentclass{ltjsarticle}
 \usepackage{doc}


### PR DESCRIPTION
v0.9から`\pdfHOGE` が廃止されて`\HOGE`になる｡
コンパイル鯖のLuaTeXはv0.9xだが､手元にはv0.8xの人も多い｡
この違いを吸収するLuaスクリプトをとりあえず埋め込んだ｡
