### PR TITLE
LuaTeX用クラスファイルから\AtBeginDocumentを削除

### DIFF
--- a/word-lua.dtx
+++ b/word-lua.dtx
@@ -3495,7 +3495,7 @@
   
   if WORD_FONT then
     tex.print(\asluastring{\PassOptionsToPackage}, "{", WORD_FONT , "}{luatexja-preset}",
-      \asluastring{\AtBeginDocument{\@ifpackageloaded{luatexja-preset}{\relax}{\usepackage{luatexja-preset}}}})
+      \asluastring{\@ifpackageloaded{luatexja-preset}{\relax}{\usepackage{luatexja-preset}}})
   end
 }
 %    \end{macrocode}


### PR DESCRIPTION
`\AtBeginDocument`がある場合、`WORD_FONT`を指定した時に正しくコンパイルされない問題を修正した。
