### PR TITLE
CIによるコンパイル時にsudoを削除した

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,11 @@ os:
   - osx
   - linux
 dist: trusty
-sudo: required
+sudo: false
 cache:
   directories:
     - "$HOME/Library/texlive/2016basic/texmf-var/luatex-cache"
+    - "$HOME/texlive/2016/texmf-var/luatex-cache"
 before_install:
   - wget https://raw.githubusercontent.com/y-yu/install-tex-travis/master/install-tex.sh
   - wget https://raw.githubusercontent.com/y-yu/install-tex-travis/master/tlmgr.sh


### PR DESCRIPTION
- Travis CIは `sudo: false` を設定すると、コンテナーベースの起動が早い環境になる
- [install-tex-travis](https://github.com/y-yu/install-tex-travis)を改良して `sudo: false` とできるようにした
- そのため、こちらの `.travis.yml` も `sudo: false` へ変更した